### PR TITLE
feat: add per-column interest level filter to Kanban board

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { Prospect } from "@shared/schema";
-import { STATUSES } from "@shared/schema";
+import { STATUSES, INTEREST_LEVELS } from "@shared/schema";
 import { ProspectCard } from "@/components/prospect-card";
 import { AddProspectForm } from "@/components/add-prospect-form";
 import { Briefcase, Plus } from "lucide-react";
@@ -26,6 +26,10 @@ const columnColors: Record<string, string> = {
   Withdrawn: "bg-gray-500",
 };
 
+type InterestFilter = "All" | typeof INTEREST_LEVELS[number];
+
+const FILTER_OPTIONS: InterestFilter[] = ["All", ...INTEREST_LEVELS];
+
 function KanbanColumn({
   status,
   prospects,
@@ -35,6 +39,13 @@ function KanbanColumn({
   prospects: Prospect[];
   isLoading: boolean;
 }) {
+  const [interestFilter, setInterestFilter] = useState<InterestFilter>("All");
+
+  const filteredProspects =
+    interestFilter === "All"
+      ? prospects
+      : prospects.filter((p) => p.interestLevel === interestFilter);
+
   return (
     <div
       className="flex flex-col min-w-[260px] max-w-[320px] w-full bg-muted/40 rounded-md"
@@ -48,9 +59,33 @@ function KanbanColumn({
           className="ml-auto text-[10px] px-1.5 py-0 h-5 min-w-[20px] flex items-center justify-center no-default-active-elevate"
           data-testid={`badge-count-${status.replace(/\s+/g, "-").toLowerCase()}`}
         >
-          {prospects.length}
+          {filteredProspects.length}
         </Badge>
       </div>
+
+      <div className="flex items-center gap-1 px-2 pt-2 pb-1">
+        {FILTER_OPTIONS.map((option) => (
+          <button
+            key={option}
+            onClick={() => setInterestFilter(option)}
+            data-testid={`filter-${status.replace(/\s+/g, "-").toLowerCase()}-${option.toLowerCase()}`}
+            className={`flex-1 text-[10px] font-medium py-0.5 rounded transition-colors ${
+              interestFilter === option
+                ? option === "All"
+                  ? "bg-primary text-primary-foreground"
+                  : option === "High"
+                  ? "bg-red-500 text-white"
+                  : option === "Medium"
+                  ? "bg-amber-500 text-white"
+                  : "bg-muted-foreground/30 text-foreground"
+                : "text-muted-foreground hover:text-foreground hover:bg-muted"
+            }`}
+          >
+            {option}
+          </button>
+        ))}
+      </div>
+
       <div className="flex-1 overflow-y-auto px-2 py-2">
         <div className="space-y-2">
           {isLoading ? (
@@ -58,12 +93,14 @@ function KanbanColumn({
               <Skeleton className="h-28 rounded-md" />
               <Skeleton className="h-20 rounded-md" />
             </>
-          ) : prospects.length === 0 ? (
+          ) : filteredProspects.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-8 text-center" data-testid={`empty-${status.replace(/\s+/g, "-").toLowerCase()}`}>
-              <p className="text-xs text-muted-foreground">No prospects</p>
+              <p className="text-xs text-muted-foreground">
+                {interestFilter === "All" ? "No prospects" : `No ${interestFilter} interest prospects`}
+              </p>
             </div>
           ) : (
-            prospects.map((prospect) => (
+            filteredProspects.map((prospect) => (
               <ProspectCard key={prospect.id} prospect={prospect} />
             ))
           )}


### PR DESCRIPTION
## Summary
  Adds a client-side interest level filter to each Kanban column.

  Closes #2

  ## Changes
  - Each status column now has its own independent filter bar (All / High / Medium / Low)
  - Selecting a filter shows only matching cards in that column; other columns are unaffected
  - Selecting "All" restores all cards
  - Badge count in the column header reflects the filtered count
  - No server calls — purely client-side filtering
  - Active filter button is color-coded (All = primary, High = red, Medium = amber, Low = muted)

  ## Screenshots
  Each column header now shows: `All | High | Medium | Low` buttons