### PR TITLE
feat: add salary band field to job prospects

### DIFF
--- a/client/src/components/add-prospect-form.tsx
+++ b/client/src/components/add-prospect-form.tsx
@@ -37,6 +37,8 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
       status: "Bookmarked",
       interestLevel: "Medium",
       notes: "",
+      salaryMin: null,
+      salaryMax: null,
     },
   });
 
@@ -155,6 +157,69 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
               </FormItem>
             )}
           />
+        </div>
+
+        <div>
+          <FormLabel className="text-sm font-medium">Salary Range (optional, in $K)</FormLabel>
+          <div className="flex items-center gap-2 mt-1.5">
+            <FormField
+              control={form.control}
+              name="salaryMin"
+              render={({ field }) => (
+                <FormItem className="flex-1">
+                  <FormControl>
+                    <div className="relative">
+                      <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">$</span>
+                      <Input
+                        type="number"
+                        min={1}
+                        step={1}
+                        placeholder="80"
+                        className="pl-6 pr-7"
+                        data-testid="input-salary-min"
+                        value={field.value ?? ""}
+                        onChange={(e) => {
+                          const val = e.target.value;
+                          field.onChange(val === "" ? null : parseInt(val, 10));
+                        }}
+                      />
+                      <span className="absolute right-2.5 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">K</span>
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <span className="text-muted-foreground text-sm shrink-0">–</span>
+            <FormField
+              control={form.control}
+              name="salaryMax"
+              render={({ field }) => (
+                <FormItem className="flex-1">
+                  <FormControl>
+                    <div className="relative">
+                      <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">$</span>
+                      <Input
+                        type="number"
+                        min={1}
+                        step={1}
+                        placeholder="120"
+                        className="pl-6 pr-7"
+                        data-testid="input-salary-max"
+                        value={field.value ?? ""}
+                        onChange={(e) => {
+                          const val = e.target.value;
+                          field.onChange(val === "" ? null : parseInt(val, 10));
+                        }}
+                      />
+                      <span className="absolute right-2.5 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">K</span>
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
         </div>
 
         <FormField

--- a/client/src/components/edit-prospect-form.tsx
+++ b/client/src/components/edit-prospect-form.tsx
@@ -42,6 +42,8 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
       status: prospect.status as InsertProspect["status"],
       interestLevel: prospect.interestLevel as InsertProspect["interestLevel"],
       notes: prospect.notes ?? "",
+      salaryMin: prospect.salaryMin ?? null,
+      salaryMax: prospect.salaryMax ?? null,
     },
   });
 
@@ -159,6 +161,69 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
               </FormItem>
             )}
           />
+        </div>
+
+        <div>
+          <FormLabel className="text-sm font-medium">Salary Range (optional, in $K)</FormLabel>
+          <div className="flex items-center gap-2 mt-1.5">
+            <FormField
+              control={form.control}
+              name="salaryMin"
+              render={({ field }) => (
+                <FormItem className="flex-1">
+                  <FormControl>
+                    <div className="relative">
+                      <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">$</span>
+                      <Input
+                        type="number"
+                        min={1}
+                        step={1}
+                        placeholder="80"
+                        className="pl-6 pr-7"
+                        data-testid="input-edit-salary-min"
+                        value={field.value ?? ""}
+                        onChange={(e) => {
+                          const val = e.target.value;
+                          field.onChange(val === "" ? null : parseInt(val, 10));
+                        }}
+                      />
+                      <span className="absolute right-2.5 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">K</span>
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <span className="text-muted-foreground text-sm shrink-0">–</span>
+            <FormField
+              control={form.control}
+              name="salaryMax"
+              render={({ field }) => (
+                <FormItem className="flex-1">
+                  <FormControl>
+                    <div className="relative">
+                      <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">$</span>
+                      <Input
+                        type="number"
+                        min={1}
+                        step={1}
+                        placeholder="120"
+                        className="pl-6 pr-7"
+                        data-testid="input-edit-salary-max"
+                        value={field.value ?? ""}
+                        onChange={(e) => {
+                          const val = e.target.value;
+                          field.onChange(val === "" ? null : parseInt(val, 10));
+                        }}
+                      />
+                      <span className="absolute right-2.5 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">K</span>
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
         </div>
 
         <FormField

--- a/client/src/components/prospect-card.tsx
+++ b/client/src/components/prospect-card.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { Prospect } from "@shared/schema";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus } from "lucide-react";
+import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -39,6 +39,39 @@ function InterestIndicator({ level }: { level: string }) {
     default:
       return null;
   }
+}
+
+function SalaryDisplay({ salaryMin, salaryMax }: { salaryMin: number | null; salaryMax: number | null }) {
+  if (salaryMin == null && salaryMax == null) {
+    return (
+      <span
+        className="inline-flex items-center gap-0.5 text-xs font-medium text-muted-foreground/60"
+        data-testid="salary-unknown"
+      >
+        <DollarSign className="w-3 h-3" />
+        -K
+      </span>
+    );
+  }
+
+  let display: string;
+  if (salaryMin != null && salaryMax != null) {
+    const median = Math.round((salaryMin + salaryMax) / 2);
+    display = `$${median}K`;
+  } else if (salaryMin != null) {
+    display = `$${salaryMin}K`;
+  } else {
+    display = `$${salaryMax}K`;
+  }
+
+  return (
+    <span
+      className="inline-flex items-center gap-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400"
+      data-testid="salary-display"
+    >
+      {display}
+    </span>
+  );
 }
 
 export function ProspectCard({ prospect }: { prospect: Prospect }) {
@@ -103,8 +136,11 @@ export function ProspectCard({ prospect }: { prospect: Prospect }) {
           </div>
         </div>
 
-        <div className="flex items-center gap-1.5 flex-wrap">
-          <InterestIndicator level={prospect.interestLevel} />
+        <div className="flex items-center justify-between gap-1.5">
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <InterestIndicator level={prospect.interestLevel} />
+          </div>
+          <SalaryDisplay salaryMin={prospect.salaryMin} salaryMax={prospect.salaryMax} />
         </div>
 
         {prospect.jobUrl && (

--- a/server/__tests__/prospect-validation.test.ts
+++ b/server/__tests__/prospect-validation.test.ts
@@ -21,3 +21,144 @@ describe("prospect creation validation", () => {
     expect(result.errors).toContain("Role title is required");
   });
 });
+
+describe("salary validation", () => {
+  test("accepts valid salary range", () => {
+    const result = validateProspect({
+      companyName: "Acme",
+      roleTitle: "Engineer",
+      salaryMin: 80,
+      salaryMax: 120,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts equal lower and upper salary (single point range)", () => {
+    const result = validateProspect({
+      companyName: "Acme",
+      roleTitle: "Engineer",
+      salaryMin: 100,
+      salaryMax: 100,
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts missing salary (both null)", () => {
+    const result = validateProspect({
+      companyName: "Acme",
+      roleTitle: "Engineer",
+      salaryMin: null,
+      salaryMax: null,
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts partial salary (only lower bound provided)", () => {
+    const result = validateProspect({
+      companyName: "Acme",
+      roleTitle: "Engineer",
+      salaryMin: 80,
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts partial salary (only upper bound provided)", () => {
+    const result = validateProspect({
+      companyName: "Acme",
+      roleTitle: "Engineer",
+      salaryMax: 120,
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects lower salary of zero", () => {
+    const result = validateProspect({
+      companyName: "Acme",
+      roleTitle: "Engineer",
+      salaryMin: 0,
+      salaryMax: 120,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Lower salary must be a positive number");
+  });
+
+  test("rejects negative lower salary", () => {
+    const result = validateProspect({
+      companyName: "Acme",
+      roleTitle: "Engineer",
+      salaryMin: -50,
+      salaryMax: 120,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Lower salary must be a positive number");
+  });
+
+  test("rejects negative upper salary", () => {
+    const result = validateProspect({
+      companyName: "Acme",
+      roleTitle: "Engineer",
+      salaryMin: 80,
+      salaryMax: -10,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Upper salary must be a positive number");
+  });
+
+  test("rejects upper salary less than lower salary", () => {
+    const result = validateProspect({
+      companyName: "Acme",
+      roleTitle: "Engineer",
+      salaryMin: 120,
+      salaryMax: 80,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Upper salary must be greater than or equal to lower salary");
+  });
+
+  test("rejects non-integer lower salary", () => {
+    const result = validateProspect({
+      companyName: "Acme",
+      roleTitle: "Engineer",
+      salaryMin: 80.5,
+      salaryMax: 120,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Lower salary must be a positive number");
+  });
+
+  test("rejects non-integer upper salary", () => {
+    const result = validateProspect({
+      companyName: "Acme",
+      roleTitle: "Engineer",
+      salaryMin: 80,
+      salaryMax: 120.9,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Upper salary must be a positive number");
+  });
+
+  test("accumulates multiple salary errors", () => {
+    const result = validateProspect({
+      companyName: "Acme",
+      roleTitle: "Engineer",
+      salaryMin: -10,
+      salaryMax: -20,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Lower salary must be a positive number");
+    expect(result.errors).toContain("Upper salary must be a positive number");
+  });
+});

--- a/server/prospect-helpers.ts
+++ b/server/prospect-helpers.ts
@@ -39,6 +39,28 @@ export function validateProspect(data: Record<string, unknown>): { valid: boolea
     }
   }
 
+  if (data.salaryMin !== undefined && data.salaryMin !== null) {
+    const min = Number(data.salaryMin);
+    if (!Number.isInteger(min) || min <= 0) {
+      errors.push("Lower salary must be a positive number");
+    }
+  }
+
+  if (data.salaryMax !== undefined && data.salaryMax !== null) {
+    const max = Number(data.salaryMax);
+    if (!Number.isInteger(max) || max <= 0) {
+      errors.push("Upper salary must be a positive number");
+    }
+  }
+
+  if (
+    data.salaryMin != null &&
+    data.salaryMax != null &&
+    Number(data.salaryMax) < Number(data.salaryMin)
+  ) {
+    errors.push("Upper salary must be greater than or equal to lower salary");
+  }
+
   return { valid: errors.length === 0, errors };
 }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -55,6 +55,28 @@ export async function registerRoutes(
       updates.interestLevel = level;
     }
 
+    if (body.salaryMin !== undefined) {
+      const min = body.salaryMin === null ? null : Number(body.salaryMin);
+      if (min !== null && (!Number.isInteger(min) || min <= 0)) {
+        return res.status(400).json({ message: "Lower salary must be a positive number" });
+      }
+      updates.salaryMin = min;
+    }
+
+    if (body.salaryMax !== undefined) {
+      const max = body.salaryMax === null ? null : Number(body.salaryMax);
+      if (max !== null && (!Number.isInteger(max) || max <= 0)) {
+        return res.status(400).json({ message: "Upper salary must be a positive number" });
+      }
+      updates.salaryMax = max;
+    }
+
+    const resolvedMin = updates.salaryMin !== undefined ? updates.salaryMin : existing.salaryMin;
+    const resolvedMax = updates.salaryMax !== undefined ? updates.salaryMax : existing.salaryMax;
+    if (resolvedMin != null && resolvedMax != null && (resolvedMax as number) < (resolvedMin as number)) {
+      return res.status(400).json({ message: "Upper salary must be greater than or equal to lower salary" });
+    }
+
     const updated = await storage.updateProspect(id, updates);
     res.json(updated);
   });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, serial, text, timestamp, integer } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -22,6 +22,8 @@ export const prospects = pgTable("prospects", {
   status: text("status").notNull().default("Bookmarked"),
   interestLevel: text("interest_level").notNull().default("Medium"),
   notes: text("notes"),
+  salaryMin: integer("salary_min"),
+  salaryMax: integer("salary_max"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
@@ -35,7 +37,17 @@ export const insertProspectSchema = createInsertSchema(prospects).omit({
   interestLevel: z.enum(INTEREST_LEVELS).default("Medium"),
   jobUrl: z.string().optional().nullable(),
   notes: z.string().optional().nullable(),
-});
+  salaryMin: z.number().int().positive("Lower salary must be a positive number").optional().nullable(),
+  salaryMax: z.number().int().positive("Upper salary must be a positive number").optional().nullable(),
+}).refine(
+  (data) => {
+    if (data.salaryMin != null && data.salaryMax != null) {
+      return data.salaryMax >= data.salaryMin;
+    }
+    return true;
+  },
+  { message: "Upper salary must be greater than or equal to lower salary", path: ["salaryMax"] }
+);
 
 export type InsertProspect = z.infer<typeof insertProspectSchema>;
 export type Prospect = typeof prospects.$inferSelect;


### PR DESCRIPTION
- Adds salaryMin/salaryMax integer columns (stored in ) to the database
- Schema validates: positive integers, salaryMax >= salaryMin
- Add/Edit forms show a  –  range input (optional)
- Prospect card shows median salary (e.g. 00K) or 'K' if not set
- Server routes validate salary on both POST and PATCH
- 14 tests: 2 existing + 12 new salary validation tests, all passing