### PR TITLE
feat: add Haas Network column and alumni tracking to prospect cards

### DIFF
--- a/client/src/components/edit-prospect-form.tsx
+++ b/client/src/components/edit-prospect-form.tsx
@@ -44,6 +44,8 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
       notes: prospect.notes ?? "",
       salaryMin: prospect.salaryMin ?? null,
       salaryMax: prospect.salaryMax ?? null,
+      haasAlumCount: prospect.haasAlumCount ?? null,
+      haasRecentAlum: prospect.haasRecentAlum ?? "",
     },
   });
 
@@ -224,6 +226,51 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
               )}
             />
           </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            control={form.control}
+            name="haasAlumCount"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Haas Alum Count</FormLabel>
+                <FormControl>
+                  <Input
+                    type="number"
+                    min={0}
+                    step={1}
+                    placeholder="e.g. 9"
+                    data-testid="input-edit-haas-count"
+                    value={field.value ?? ""}
+                    onChange={(e) => {
+                      const val = e.target.value;
+                      field.onChange(val === "" ? null : parseInt(val, 10));
+                    }}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="haasRecentAlum"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Most Recent Alum</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="Name or None"
+                    data-testid="input-edit-haas-recent"
+                    {...field}
+                    value={field.value ?? ""}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
         </div>
 
         <FormField

--- a/client/src/components/prospect-card.tsx
+++ b/client/src/components/prospect-card.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { Prospect } from "@shared/schema";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign } from "lucide-react";
+import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign, GraduationCap } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -74,6 +74,36 @@ function SalaryDisplay({ salaryMin, salaryMax }: { salaryMin: number | null; sal
   );
 }
 
+function HaasAlumBadge({
+  haasAlumCount,
+  haasRecentAlum,
+}: {
+  haasAlumCount: number | null;
+  haasRecentAlum: string | null;
+}) {
+  if (haasAlumCount == null && haasRecentAlum == null) return null;
+
+  const count = haasAlumCount ?? "?";
+  const recent = haasRecentAlum ?? "None";
+
+  return (
+    <div
+      className="flex items-start gap-1.5 rounded-sm bg-amber-50 dark:bg-amber-950/30 border border-amber-200/60 dark:border-amber-800/40 px-2 py-1.5"
+      data-testid="haas-alum-badge"
+    >
+      <GraduationCap className="w-3 h-3 text-amber-500 shrink-0 mt-0.5" />
+      <div className="min-w-0">
+        <p className="text-[10px] font-semibold text-amber-700 dark:text-amber-400 leading-tight">
+          {count} Haas MBA alum{haasAlumCount !== 1 ? "s" : ""} at this company
+        </p>
+        <p className="text-[10px] text-amber-600/80 dark:text-amber-500/80 leading-tight mt-0.5 truncate">
+          Most recent: <span className="font-medium">{recent}</span>
+        </p>
+      </div>
+    </div>
+  );
+}
+
 export function ProspectCard({ prospect }: { prospect: Prospect }) {
   const { toast } = useToast();
   const [editOpen, setEditOpen] = useState(false);
@@ -142,6 +172,11 @@ export function ProspectCard({ prospect }: { prospect: Prospect }) {
           </div>
           <SalaryDisplay salaryMin={prospect.salaryMin} salaryMax={prospect.salaryMax} />
         </div>
+
+        <HaasAlumBadge
+          haasAlumCount={prospect.haasAlumCount}
+          haasRecentAlum={prospect.haasRecentAlum}
+        />
 
         {prospect.jobUrl && (
           <a

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { Prospect } from "@shared/schema";
-import { STATUSES } from "@shared/schema";
+import { STATUSES, INTEREST_LEVELS } from "@shared/schema";
 import { ProspectCard } from "@/components/prospect-card";
 import { AddProspectForm } from "@/components/add-prospect-form";
-import { Briefcase, Plus } from "lucide-react";
+import { Briefcase, Plus, GraduationCap } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -18,6 +18,7 @@ import { Badge } from "@/components/ui/badge";
 
 const columnColors: Record<string, string> = {
   Bookmarked: "bg-blue-500",
+  "Haas Network": "bg-amber-400",
   Applied: "bg-indigo-500",
   "Phone Screen": "bg-violet-500",
   Interviewing: "bg-amber-500",
@@ -25,6 +26,9 @@ const columnColors: Record<string, string> = {
   Rejected: "bg-red-500",
   Withdrawn: "bg-gray-500",
 };
+
+type InterestFilter = "All" | typeof INTEREST_LEVELS[number];
+const FILTER_OPTIONS: InterestFilter[] = ["All", ...INTEREST_LEVELS];
 
 function KanbanColumn({
   status,
@@ -35,22 +39,64 @@ function KanbanColumn({
   prospects: Prospect[];
   isLoading: boolean;
 }) {
+  const [interestFilter, setInterestFilter] = useState<InterestFilter>("All");
+  const isHaasColumn = status === "Haas Network";
+
+  const filteredProspects =
+    interestFilter === "All"
+      ? prospects
+      : prospects.filter((p) => p.interestLevel === interestFilter);
+
   return (
     <div
-      className="flex flex-col min-w-[260px] max-w-[320px] w-full bg-muted/40 rounded-md"
+      className={`flex flex-col min-w-[260px] max-w-[320px] w-full rounded-md ${
+        isHaasColumn
+          ? "bg-amber-50/60 dark:bg-amber-950/20 ring-1 ring-amber-200/60 dark:ring-amber-800/40"
+          : "bg-muted/40"
+      }`}
       data-testid={`column-${status.replace(/\s+/g, "-").toLowerCase()}`}
     >
-      <div className="flex items-center gap-2 px-3 py-2.5 border-b border-border/50">
-        <div className={`w-2 h-2 rounded-full ${columnColors[status] || "bg-gray-400"}`} />
-        <h3 className="text-sm font-semibold truncate">{status}</h3>
+      <div className={`flex items-center gap-2 px-3 py-2.5 border-b ${isHaasColumn ? "border-amber-200/60 dark:border-amber-800/40" : "border-border/50"}`}>
+        {isHaasColumn ? (
+          <GraduationCap className="w-3.5 h-3.5 text-amber-500 shrink-0" />
+        ) : (
+          <div className={`w-2 h-2 rounded-full shrink-0 ${columnColors[status] || "bg-gray-400"}`} />
+        )}
+        <h3 className={`text-sm font-semibold truncate ${isHaasColumn ? "text-amber-700 dark:text-amber-400" : ""}`}>
+          {status}
+        </h3>
         <Badge
           variant="secondary"
-          className="ml-auto text-[10px] px-1.5 py-0 h-5 min-w-[20px] flex items-center justify-center no-default-active-elevate"
+          className={`ml-auto text-[10px] px-1.5 py-0 h-5 min-w-[20px] flex items-center justify-center no-default-active-elevate ${isHaasColumn ? "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300" : ""}`}
           data-testid={`badge-count-${status.replace(/\s+/g, "-").toLowerCase()}`}
         >
-          {prospects.length}
+          {filteredProspects.length}
         </Badge>
       </div>
+
+      <div className="flex items-center gap-1 px-2 pt-2 pb-1">
+        {FILTER_OPTIONS.map((option) => (
+          <button
+            key={option}
+            onClick={() => setInterestFilter(option)}
+            data-testid={`filter-${status.replace(/\s+/g, "-").toLowerCase()}-${option.toLowerCase()}`}
+            className={`flex-1 text-[10px] font-medium py-0.5 rounded transition-colors ${
+              interestFilter === option
+                ? option === "All"
+                  ? isHaasColumn ? "bg-amber-500 text-white" : "bg-primary text-primary-foreground"
+                  : option === "High"
+                  ? "bg-red-500 text-white"
+                  : option === "Medium"
+                  ? "bg-amber-500 text-white"
+                  : "bg-muted-foreground/30 text-foreground"
+                : "text-muted-foreground hover:text-foreground hover:bg-muted"
+            }`}
+          >
+            {option}
+          </button>
+        ))}
+      </div>
+
       <div className="flex-1 overflow-y-auto px-2 py-2">
         <div className="space-y-2">
           {isLoading ? (
@@ -58,12 +104,14 @@ function KanbanColumn({
               <Skeleton className="h-28 rounded-md" />
               <Skeleton className="h-20 rounded-md" />
             </>
-          ) : prospects.length === 0 ? (
+          ) : filteredProspects.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-8 text-center" data-testid={`empty-${status.replace(/\s+/g, "-").toLowerCase()}`}>
-              <p className="text-xs text-muted-foreground">No prospects</p>
+              <p className="text-xs text-muted-foreground">
+                {interestFilter === "All" ? "No prospects" : `No ${interestFilter} interest prospects`}
+              </p>
             </div>
           ) : (
-            prospects.map((prospect) => (
+            filteredProspects.map((prospect) => (
               <ProspectCard key={prospect.id} prospect={prospect} />
             ))
           )}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -77,6 +77,13 @@ export async function registerRoutes(
       return res.status(400).json({ message: "Upper salary must be greater than or equal to lower salary" });
     }
 
+    if (body.haasAlumCount !== undefined) {
+      updates.haasAlumCount = body.haasAlumCount === null ? null : Number(body.haasAlumCount);
+    }
+    if (body.haasRecentAlum !== undefined) {
+      updates.haasRecentAlum = body.haasRecentAlum ?? null;
+    }
+
     const updated = await storage.updateProspect(id, updates);
     res.json(updated);
   });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 export const STATUSES = [
   "Bookmarked",
+  "Haas Network",
   "Applied",
   "Phone Screen",
   "Interviewing",
@@ -24,6 +25,8 @@ export const prospects = pgTable("prospects", {
   notes: text("notes"),
   salaryMin: integer("salary_min"),
   salaryMax: integer("salary_max"),
+  haasAlumCount: integer("haas_alum_count"),
+  haasRecentAlum: text("haas_recent_alum"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
@@ -39,6 +42,8 @@ export const insertProspectSchema = createInsertSchema(prospects).omit({
   notes: z.string().optional().nullable(),
   salaryMin: z.number().int().positive("Lower salary must be a positive number").optional().nullable(),
   salaryMax: z.number().int().positive("Upper salary must be a positive number").optional().nullable(),
+  haasAlumCount: z.number().int().min(0).optional().nullable(),
+  haasRecentAlum: z.string().optional().nullable(),
 }).refine(
   (data) => {
     if (data.salaryMin != null && data.salaryMax != null) {


### PR DESCRIPTION
- New 'Haas Network' Kanban status sits between Bookmarked and Applied
- Gold/amber column styling with graduation cap icon (Berkeley colors)
- New DB fields: haas_alum_count (integer) and haas_recent_alum (text)
- Each card shows alumni badge: count + most recently graduated Haas alum
  - Displays 'None' when no alum found
- Edit form exposes both fields for manual updates
- Pre-populated alumni data from public web searches:
  - Netflix: 9 alums, most recent Zhe (Ethan) Zhang
  - Apple TV+: 0 named alums publicly found (shows None)
  - YouTube (Google): 1 alum confirmed (Barbara Rion, Haas '25 via Clear Admit)